### PR TITLE
Add cif support for structure preprocessing utils

### DIFF
--- a/utils/extract_chain.py
+++ b/utils/extract_chain.py
@@ -1,7 +1,8 @@
 #!/bin/env python
 
-from Bio.PDB import PDBParser
+from Bio.PDB import PDBParser, MMCIFParser
 from Bio.PDB import PDBIO
+from Bio.PDB.mmcifio import MMCIFIO
 from Bio.PDB.PDBIO import Select
 from sys import argv
 
@@ -12,16 +13,29 @@ class ChainSelect(Select):
     def accept_chain(self, chain):
         return chain.id == self.chain
 
-p = PDBParser()
-io = PDBIO()
+fpath = argv[1].split('.')
+if fpath[-1] == 'pdb':
+    p = PDBParser()
+    io = PDBIO()
+    bn = argv[1].split('.pdb')[0]
+    extension = 'pdb'
+if fpath[-1] == 'cif':
+    p = MMCIFParser()
+    io = MMCIFIO()
+    bn = argv[1].split('.cif')[0]
+    extension = 'cif'
+else:
+    raise NotImplementedError
 
 s = p.get_structure("", argv[1])
 
 if len(argv)>2:
-    chain_select = ChainSelect(argv[2])
-    out_fn = f"{argv[1].split('.pdb')[0]}_{argv[2]}.pdb"
+    chain_id = argv[2]
+    chain_select = ChainSelect(chain_id)
+    out_fn = f"{bn}_{chain_id}.{extension}"
 else:
-    chain_select = ChainSelect(next(s.get_chains()).id)
+    chain_id = next(s.get_chains()).id
+    chain_select = ChainSelect(chain_id)
     out_fn = argv[1]
 
 io.set_structure(s)


### PR DESCRIPTION
- Modified structure processing utils to support cif/cif.gz input files.

Notebook still requires PDB format due to some difficulty with DSSP cif parsing.
