### PR TITLE
Add reportcutoff option and minor housekeeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ SPfast.gnu /path/to/id.suffix /path/to/id.suffix
 ```
 
 ## Parameters
-Note: The most impactful parameters are ssprefcut >> coarsecut > finalgap0 > convergence_criterion > segcut ~ riters
+Note: The most impactful parameters for improving sensitivity are ssprefcut >> coarsecut > finalgap0 > convergence_criterion > segcut ~ riters
 
 * **-SPscore**:
 Use original SPscore parameters rather than newly optimized parameters.
@@ -105,8 +105,15 @@ Maxmimum RMSD between seed fragments. (higher threshold means increased sensitiv
 * **-riters**: Default: 1\
 Number of superimposing iterations to convergence for a given alignment
 
-## Output Formats
-**-iprint {1,2,3}**
+## Reporting
+* **-iprint 1**:
+Display alignment scores only
+* **-iprint 2**
+Display alignment scores and transformation matrix
+* **-iprint 3**
+Display alignment scores, transformation matrix and alignment
+* **-reportcutoff**
+Filter output results by minimum score threshold
 
 ## PyMOL Plugin
 We have included a PyMOL plugin to enable pairwise alignment within PyMOL similar to builtin align/cealign functionality. The plugin can be installed with the Plugin Manager using the URL of this repository and the SPfast.py script. SPlib *must* be first installed with pip.\

--- a/src/SPfast.cc
+++ b/src/SPfast.cc
@@ -21,6 +21,7 @@ namespace Salign_PARAMS{
     int score_type=iSP, fragsize=0; 
 // iprint controls the details to print, the bigger the more printed
     int iprint=-9999;
+    double reportcutoff=-1.;
 // bscoreOnly: 0, structure alignment; others, score only (using predefined alignment)
 // 1,scored according to resi No.; 2,scored according to residues sequentially
     int bscoreOnly=0;
@@ -68,8 +69,7 @@ inline string getdir(string sdir0){
     return sdir;
 }
 void rdparams(int argc, char *argv[]){
-    string usage = "Usage: RUN [-pair pdb1 pdb2|-pairlist sdir list] [-iprint 1] [-SP|-TM|-GDT] [-fast] [-cutoff cut]"
-    ;
+    string usage = "Usage: RUN [-pair bin1 bin2|-pairlist dir pairlist|-q bin1 -t bin2|-q bin1 -tdb tdb| -qlist dir qlist .ideal.bin -tlist dir tlist .ideal.bin] [-iprint 1] [-SP|-TM|-GDT] [-fast]";
     if(argc < 3) die(usage.c_str());
     Tlist.clear(); Qlist.clear();
     fali = idir = odir = "";
@@ -160,6 +160,7 @@ void rdparams(int argc, char *argv[]){
         else if(opt1 == "-fullalign") bfullalign = 1;
         else if(opt1 == "-batchstart") batchstart = atoi(argv[++i0]);
         else if(opt1 == "-batchend") batchend = atoi(argv[++i0]);
+        else if(opt1 == "-reportcutoff") reportcutoff = strtod(argv[++i0], NULL);
         else die("unknown option: %s", argv[i0]);
         i0 ++;
     }

--- a/src/align1.cc
+++ b/src/align1.cc
@@ -1521,7 +1521,10 @@ void Salign::prtali(string &sinfo){
     char str[max(nA+nB+100,2001)];
 //
     double SPs[4];      // SPe, SPa, SPb
-    if(score_type == iSP) calSPscores(SPs);
+    if(score_type == iSP) {
+        calSPscores(SPs);
+        if (SPs[0]<reportcutoff) return;
+    }
 //
     if(iprint >= 99) {
         sprintf(str, "################## Alignment Report ##################\n"); sinfo += str;

--- a/src/extract_bin.cc
+++ b/src/extract_bin.cc
@@ -1,27 +1,13 @@
 #include "protein2.h"
 #include <inttypes.h>
 
-namespace Salign_PARAMS2{
-// alpha is the normalized factor(as seen in paper); D00 is "D0"; Denv the distance cutoff used to determine the "environment residues"
-    double Alpha=0.3, D00=4., Denv=12., cutoff=-1, gap_min=0., scaling_factor=3.75;
-// score_type decids the type of calculated alignment scores (SP, TM, GDT-scores are supported)
-// fragsize is the length of fragment for the original alignment trials during finding the best alignment
-    int score_type=iSP, fragsize=20; 
-// iprint controls the details to print, the bigger the more printed
-    int iprint=-9999;
-// bscoreOnly: 0, structure alignment; others, score only (using predefined alignment)
-// 1,scored according to resi No.; 2,scored according to residues sequentially
-    int bscoreOnly=0;
-    bool bfullalign=0;
-}
 namespace PARAMS2{
-    using namespace Salign_PARAMS2;
-//  vector<string> Tlist, Qlist;
     unordered_set<string> Qset;
     string fali, idir, odir, fdb, fdbout;
     int bpairlist=0, bcheck=0;
     vector<string> folds;
 }
+
 static string runtype = "";
 using namespace PARAMS2;
 int DEBUG = 0;
@@ -44,7 +30,7 @@ inline string getdir2(string sdir0){
 }
 
 void rdparams2(int argc, char *argv[]){
-    string usage = "Usage: RUN fdb odir [-q query / -qlist query_list] [-tdb in.db]";
+    string usage = "Usage: RUN fdb odir [-q query|-qlist query_list] [-tdb out.db]";
     if(argc < 2) die(usage.c_str());
     fali = idir = odir = "";
     int i0 = 1;

--- a/src/prepare_bin.cc
+++ b/src/prepare_bin.cc
@@ -2,21 +2,7 @@
 #include <stdint.h>
 #include <inttypes.h>
 
-namespace Salign_PARAMS2{
-// alpha is the normalized factor(as seen in paper); D00 is "D0"; Denv the distance cutoff used to determine the "environment residues"
-    double Alpha=0.3, D00=4., Denv=12., cutoff=-1, gap_min=0., scaling_factor=3.75;
-// score_type decids the type of calculated alignment scores (SP, TM, GDT-scores are supported)
-// fragsize is the length of fragment for the original alignment trials during finding the best alignment
-    int score_type=iSP, fragsize=20; 
-// iprint controls the details to print, the bigger the more printed
-    int iprint=-9999;
-// bscoreOnly: 0, structure alignment; others, score only (using predefined alignment)
-// 1,scored according to resi No.; 2,scored according to residues sequentially
-    int bscoreOnly=0;
-    bool bfullalign=0;
-}
 namespace PARAMS2{
-    using namespace Salign_PARAMS2;
     vector<string> Tlist, Qlist;
     string fali, idir, odir, fdb;
     int bpairlist=0, bcheck=0;
@@ -46,8 +32,7 @@ inline string getdir2(string sdir0){
 }
 
 void rdparams2(int argc, char *argv[]){
-    string usage = "Usage: RUN"
-    ;
+    string usage = "Usage: RUN [-q bin1|-qlist dir qlist .ideal] [-bin] [-tdb]";
     if(argc < 2) die(usage.c_str());
     Tlist.clear(); Qlist.clear();
     fali = idir = odir = "";
@@ -80,12 +65,10 @@ void rdparams2(int argc, char *argv[]){
 }
 
 void run(){
-    //FILE *fp = stdout;
     Protein2 *p1;
     for(int j=0; j<Qlist.size(); j++){
         string bn = basename(Qlist[j].c_str());
         string fn = Qlist[j] + ".bin";
-        //if (file_existed(fn)) continue;
         p1 = new Protein2();
         p1->rdideal(Qlist[j]);
         p1->wrbin(fn);
@@ -94,18 +77,14 @@ void run(){
 }
 
 void rundb(bool bin){
-    //FILE *fp = stdout;
     Protein2 *p1;
     string name;
     std::ofstream ofs(fdb, std::ios::binary);
     int n_entries = Qlist.size();
     ofs.write(reinterpret_cast<const char*>(&n_entries), sizeof(int));
-    //int offset = sizeof(int), new_offset=0;
     int64_t offset = (int64_t)sizeof(int), new_offset=(int64_t)0;
     for(int j=0; j<n_entries; j++){
         string bn = basename(Qlist[j].c_str());
-        //string fn = Qlist[j] + ".bin";
-        //if (file_existed(fn)) continue;
         name = bn + "\n";
         ofs.write(name.c_str(), name.size());
         p1 = new Protein2();
@@ -115,19 +94,15 @@ void rundb(bool bin){
             p1->rdideal(Qlist[j]);
         }
         new_offset = p1->wrbin1(ofs);
-        //printf("%s %d\n", bn.c_str(), offset);
         printf("%s %" PRId64 "\n", bn.c_str(), offset);
         offset+=(new_offset+name.size());
         delete p1;
-        //fflush(stdout);
-        //printf("%s %d %d %d\n", bn.c_str(), offset, new_offset, name.size());
     }
 }
 
 int main(int argc, char *argv[]){
     rdparams2(argc, argv);
     if(Qlist.size() < 1) die("no query selected");
-    //fflush(stdout);
     if(runtype == "") {
         run();
     } else if (runtype == "db"){

--- a/src/protein2.h
+++ b/src/protein2.h
@@ -184,7 +184,7 @@ enum {ieSP, ieTMa, ieLG, ieGDT, ieLA, ieRMS, ieLE, ieTMb, ieTMc, ieSEQ};
 namespace Salign_PARAMS{
     extern int iprint, inorm, score_type, fragsize, bscoreOnly;
     extern double Alpha, Beta, D00, Denv, cutoff, gap_min, scaling_factor;
-    extern double segcut, segalpha, ssprefcut, pref_gap0, pref_gap1, final_gap0, convergence_criterion, coarsecut;
+    extern double segcut, segalpha, ssprefcut, pref_gap0, pref_gap1, final_gap0, convergence_criterion, coarsecut, reportcutoff;
     extern int riters;
     extern bool bfullalign, bsingledom;
     extern string outpdb;


### PR DESCRIPTION
- Added -reportcutoff option to reduce size of outputs in batch runs. 
  - Mainly useful for -iprint 2/3 modes which aren't filtered by piping through a trivial awk oneliner
- Cleaned up unused code in db preparation utils (extract_bin and prepare_bin).
- Added some very minor documentation to readme and usage strings.